### PR TITLE
Fix splice optimization

### DIFF
--- a/tcpproxy.go
+++ b/tcpproxy.go
@@ -458,8 +458,8 @@ func proxyCopy(errc chan<- error, dst, src net.Conn) {
 
 	// Unwrap the src and dst from *Conn to *net.TCPConn so Go
 	// 1.11's splice optimization kicks in.
-	src = UnderlyingConn(src)
-	dst = UnderlyingConn(dst)
+	src = tcpConn(src)
+	dst = tcpConn(dst)
 
 	_, err := io.Copy(dst, src)
 	errc <- err


### PR DESCRIPTION
The intended behavior from the comment is not taking place:
```
// Unwrap the src and dst from *Conn to *net.TCPConn so Go
// 1.11's splice optimization kicks in.
src = UnderlyingConn(src)
dst = UnderlyingConn(dst)
```

The `UnderlyingConn` func doesn't return a `*net.TCPConn` so I think the intention here was to call `tcpConn` instead.